### PR TITLE
bug(previewpdf): de-select item upon previewing pdf

### DIFF
--- a/code/src/App.tsx
+++ b/code/src/App.tsx
@@ -224,7 +224,7 @@ export default function App() {
                 <input type="file" accept="application/json" onChange={handleLoadLayout} className="hidden" />
               </label>
             </Button>
-            <Button variant="outline" onClick={handlePreviewPDF}>Open PDF Preview</Button>
+            <Button variant="outline" onClick={() => { setSelectedId(null); requestAnimationFrame(() => { handlePreviewPDF(); }) }}>Open PDF Preview</Button>
           </div>
         </div>
 


### PR DESCRIPTION
When previewing pdf with a component select, the blue outline would remain. The fix de-selects the item and waits for React to re-render before taking the DOM snapshot.